### PR TITLE
fix(delagent): delagent error message wording

### DIFF
--- a/src/delagent/agent/delagent.c
+++ b/src/delagent/agent/delagent.c
@@ -151,7 +151,7 @@ int main (int argc, char *argv[])
   {
     if (1 != check_permission_del(DelUpload, user_id, user_perm))
     {
-      LOG_FATAL("You '%s' does not have the permsssion to delete the upload '%ld', or the upload '%ld' does not exist.\n", user_name, DelUpload, DelUpload);
+      LOG_FATAL("User '%s' does not have the permsssion to delete the upload '%ld', or the upload '%ld' does not exist.\n", user_name, DelUpload, DelUpload);
       exit(-1);
     }
     DeleteUpload(DelUpload); 


### PR DESCRIPTION
Changing message "You 'username' does not have permission..." to "User 'username' does not have permission..."